### PR TITLE
Add missing wget dependency found in first_time_setup.sh.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -81,6 +81,7 @@
   <run_depend>postgresql-postgis</run_depend>
   <run_depend>curl</run_depend>
   <run_depend>unzip</run_depend>
+  <run_depend>wget</run_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->


### PR DESCRIPTION
`first_time_setup.sh` currently errors out when run with a `command not found` error due to a missing `wget` dependency configuration in `package.xml`. 

Fixes #93. 